### PR TITLE
chore: add deprecation dates to homepage and changelog

### DIFF
--- a/static/api.html
+++ b/static/api.html
@@ -27,7 +27,7 @@
     "link": "https://gordhoard.org",
     "generator": "owo",
     "metadata": "OWOIFY"
-    }</code>
+}</code>
   <p>
     <code>link</code> is a valid HTTP/S scheme link that the user is to be
     redirected to.
@@ -55,8 +55,8 @@
   <h2>Deprecated Endpoints</h2>
   <p>
     As of 2023-04-01, the <code>/generate</code> and <code>/info</code> endpoints are deprecated. These endpoints will
-    continue to funtion for the time being, but should not be relied on. They are likely to be removed at some point in
-    the future.
+    continue to function for the time being, but should not be relied on. These API endpoints are scheduled to be removed
+    on August 1, 2023.
   </p>
 </div>
 <div id="footer">

--- a/static/changelog.html
+++ b/static/changelog.html
@@ -16,9 +16,9 @@
   <h3 id="2023-04-01">2023-04-01</h3>
   <p>
     owo.vc's backend has been rewritten from scratch, making the API more RESTful as well as cleaning up the codebase
-    considerably. Old API endpoints are still available for backwards compatibility, however they are now deprecated,
-    and it is planned to remove them at a future date. A minimum of four months will be given before removal for the
-    migration of any existing clients relying on these endpoints.
+    considerably. Old API endpoints are still available for backwards compatibility, but are scheduled for removal on
+    August 1, 2023. This date may be extended if a significant portion of users continue to use these deprecated
+    endpoints.
   </p>
   <p>Notable changes in this release are as follows:</p>
   <ul>

--- a/static/index.html
+++ b/static/index.html
@@ -37,6 +37,15 @@
 </div>
 <br>
 <hr>
+<div class="documentation">
+  <h3>Notice:</h3>
+  <p>
+    owo.vc's original version 1 API endpoints will be deprecated on August 1, 2023. If you are a developer, please make
+    sure you update your applications to use the latest API version. For more information, check the
+    <a href="https://owo.vc/changelog.html#2023-04-01">changelog</a>.
+  </p>
+</div>
+<hr>
 <p>
   Have an owo.vc link and want to get some information on it? Throw it in
   here, and we'll look it up for you.


### PR DESCRIPTION
This adds additional dates for the deprecation of the old API endpoints.